### PR TITLE
Dynamic Masters POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ module "dcos-infrastructure" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | admin_ips | List of CIDR admin IPs | list | - | yes |
-| azurem_storage_account_name | The Azure Storage Account Name for External Exhibitor | string | `` | no |
+| azurerm_storage_account_name | The Azure Storage Account Name for External Exhibitor | string | `` | no |
 | bootstrap_admin_username | Bootstrap node SSH User | string | `` | no |
 | bootstrap_dcos_instance_os | Bootstrap node tested OSes image | string | `` | no |
 | bootstrap_disk_size | Bootstrap node disk size (gb) | string | `` | no |
@@ -70,7 +70,7 @@ module "dcos-infrastructure" {
 
 | Name | Description |
 |------|-------------|
-| azurem_storage_key | Storage Key |
+| azurerm_storage_key | Storage Key |
 | bootstrap.admin_username | Deployed bootstrap agent SSH user |
 | bootstrap.prereq_id | Returns the ID of the prereq script |
 | bootstrap.private_ip | Bootstrap private ip |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module creates typical DS/OS infrastructure in Azure.
 ```hcl
 module "dcos-infrastructure" {
   source  = "terraform-dcos/infrastructure/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   infra_public_ssh_key_path = "~/.ssh/id_rsa.pub"
 
@@ -24,6 +24,7 @@ module "dcos-infrastructure" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | admin_ips | List of CIDR admin IPs | list | - | yes |
+| azurem_storage_account_name | The Azure Storage Account Name for External Exhibitor | string | `` | no |
 | bootstrap_admin_username | Bootstrap node SSH User | string | `` | no |
 | bootstrap_dcos_instance_os | Bootstrap node tested OSes image | string | `` | no |
 | bootstrap_disk_size | Bootstrap node disk size (gb) | string | `` | no |
@@ -69,6 +70,7 @@ module "dcos-infrastructure" {
 
 | Name | Description |
 |------|-------------|
+| azurem_storage_key | Storage Key |
 | bootstrap.admin_username | Deployed bootstrap agent SSH user |
 | bootstrap.prereq_id | Returns the ID of the prereq script |
 | bootstrap.private_ip | Bootstrap private ip |

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  * ```hcl
  * module "dcos-infrastructure" {
  *   source  = "terraform-dcos/infrastructure/azurerm"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   infra_public_ssh_key_path = "~/.ssh/id_rsa.pub"
  *
@@ -69,6 +69,17 @@ module "network-security-group" {
 
   resource_group_name = "${azurerm_resource_group.rg.name}"
   tags                = "${var.tags}"
+}
+
+// If External Exhibitor is Specified, Create a Storage Account
+resource "azurerm_storage_account" "external_exhibitor" {
+  count                    = "${var.azurem_storage_account_name != "" ? 1 : 0}"
+  name                     = "${var.azurem_storage_account_name}"
+  resource_group_name      = "${azurerm_resource_group.rg.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  tags                     = "${var.tags}"
 }
 
 module "loadbalancers" {

--- a/main.tf
+++ b/main.tf
@@ -73,8 +73,8 @@ module "network-security-group" {
 
 // If External Exhibitor is Specified, Create a Storage Account
 resource "azurerm_storage_account" "external_exhibitor" {
-  count                    = "${var.azurem_storage_account_name != "" ? 1 : 0}"
-  name                     = "${var.azurem_storage_account_name}"
+  count                    = "${var.azurerm_storage_account_name != "" ? 1 : 0}"
+  name                     = "${var.azurerm_storage_account_name}"
   resource_group_name      = "${azurerm_resource_group.rg.name}"
   location                 = "${var.location}"
   account_tier             = "Standard"

--- a/outputs.tf
+++ b/outputs.tf
@@ -113,7 +113,7 @@ output "lb.public-agents" {
 }
 
 # Storage Key
-output "azurem_storage_key" {
+output "azurerm_storage_key" {
   description = "Azure Storage Account Access Keys for External Exhibitor"
   value       = "${join(",", flatten(azurerm_storage_account.external_exhibitor.*.primary_access_key))}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -117,5 +117,3 @@ output "azurem_storage_key" {
   description = "Azure Storage Account Access Keys for External Exhibitor"
   value       = "${join(",", flatten(azurerm_storage_account.external_exhibitor.*.primary_access_key))}"
 }
-
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -111,3 +111,11 @@ output "lb.public-agents" {
   description = "lb address"
   value       = "${module.loadbalancers.public-agents.lb_address}"
 }
+
+# Storage Key
+output "azurem_storage_key" {
+  description = "Azure Storage Account Access Keys for External Exhibitor"
+  value       = "${join(",", flatten(azurerm_storage_account.external_exhibitor.*.primary_access_key))}"
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -245,3 +245,8 @@ variable "public_agents_additional_ports" {
   description = "List of additional ports allowed for public access on public agents (80 and 443 open by default)"
   default     = []
 }
+
+variable "azurem_storage_account_name" {
+  description = "The Azure Storage Account Name for External Exhibitor"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -246,7 +246,7 @@ variable "public_agents_additional_ports" {
   default     = []
 }
 
-variable "azurem_storage_account_name" {
+variable "azurerm_storage_account_name" {
   description = "The Azure Storage Account Name for External Exhibitor"
   default     = ""
 }


### PR DESCRIPTION
- If the user specifies a variable to add storage account name (azurem_storage_account_name), then it will create a storage account. It will be ignored if not. This is for External Exhibitor functionality for replaceable Masters feature.

- Added azure_store_key to outputs so that it can be passed as the account key so masters can write and read from the storage account using the module output. 

- Updated the variables in the README and in the variables spreadsheet to reflect

