### PR TITLE
Update to latest Azure Provider APIs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,6 +94,8 @@ module "loadbalancers" {
   cluster_name                   = "${var.cluster_name}"
   subnet_id                      = "${module.network.subnet_id}"
   public_agents_additional_rules = ["${data.null_data_source.lb_rules.*.outputs}"]
+  master_instance_nic_ids        = ["${module.masters.instance_nic_ids}"]
+  public_instance_nic_ids        = ["${module.public_agents.instance_nic_ids}"]
 
   resource_group_name = "${azurerm_resource_group.rg.name}"
   tags                = "${var.tags}"
@@ -146,8 +148,8 @@ module "masters" {
   resource_group_name          = "${azurerm_resource_group.rg.name}"
   subnet_id                    = "${module.network.subnet_id}"
   network_security_group_id    = "${module.network-security-group.masters.nsg_id}"
-  public_backend_address_pool  = ["${module.loadbalancers.masters.backend_address_pool}"]
-  private_backend_address_pool = ["${module.loadbalancers.masters-internal.backend_address_pool}"]
+  public_backend_address_pool  = "${module.loadbalancers.masters.backend_address_pool}"
+  private_backend_address_pool = "${module.loadbalancers.masters-internal.backend_address_pool}"
 
   # Determine if we need to force a particular location
   dcos_version = "${var.dcos_version}"
@@ -202,7 +204,7 @@ module "public_agents" {
   resource_group_name         = "${azurerm_resource_group.rg.name}"
   subnet_id                   = "${module.network.subnet_id}"
   network_security_group_id   = "${module.network-security-group.public_agents.nsg_id}"
-  public_backend_address_pool = ["${module.loadbalancers.public-agents.backend_address_pool}"]
+  public_backend_address_pool = "${module.loadbalancers.public-agents.backend_address_pool}"
 
   # Determine if we need to force a particular location
   dcos_version = "${var.dcos_version}"

--- a/main.tf
+++ b/main.tf
@@ -90,12 +90,16 @@ module "loadbalancers" {
     azurerm = "azurerm"
   }
 
-  location                       = "${var.location}"
-  cluster_name                   = "${var.cluster_name}"
-  subnet_id                      = "${module.network.subnet_id}"
-  public_agents_additional_rules = ["${data.null_data_source.lb_rules.*.outputs}"]
-  master_instance_nic_ids        = ["${module.masters.instance_nic_ids}"]
-  public_instance_nic_ids        = ["${module.public_agents.instance_nic_ids}"]
+  location                             = "${var.location}"
+  cluster_name                         = "${var.cluster_name}"
+  subnet_id                            = "${module.network.subnet_id}"
+  public_agents_additional_rules       = ["${data.null_data_source.lb_rules.*.outputs}"]
+  masters_instance_nic_ids             = ["${module.masters.instance_nic_ids}"]
+  public_agents_instance_nic_ids       = ["${module.public_agents.instance_nic_ids}"]
+  masters_ip_configuration_names       = ["${module.masters.ip_configuration_names}"]
+  public_agents_ip_configuration_names = ["${module.public_agents.ip_configuration_names}"]
+  num_masters                          = "${var.num_masters}"
+  num_public_agents                    = "${var.num_public_agents}"
 
   resource_group_name = "${azurerm_resource_group.rg.name}"
   tags                = "${var.tags}"
@@ -148,8 +152,6 @@ module "masters" {
   resource_group_name          = "${azurerm_resource_group.rg.name}"
   subnet_id                    = "${module.network.subnet_id}"
   network_security_group_id    = "${module.network-security-group.masters.nsg_id}"
-  public_backend_address_pool  = "${module.loadbalancers.masters.backend_address_pool}"
-  private_backend_address_pool = "${module.loadbalancers.masters-internal.backend_address_pool}"
 
   # Determine if we need to force a particular location
   dcos_version = "${var.dcos_version}"
@@ -204,7 +206,6 @@ module "public_agents" {
   resource_group_name         = "${azurerm_resource_group.rg.name}"
   subnet_id                   = "${module.network.subnet_id}"
   network_security_group_id   = "${module.network-security-group.public_agents.nsg_id}"
-  public_backend_address_pool = "${module.loadbalancers.public-agents.backend_address_pool}"
 
   # Determine if we need to force a particular location
   dcos_version = "${var.dcos_version}"


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49945

Azure has deprecated some of their api and requires universal installer updates in order for us to continue to use these changes. Whenever there is a new resource introduced into the templates, this is considered a breaking change to our definition and requires an update to a minor version of the universal installer.

There is a limitation/workaround here that was used within these 0.2 change that will be updated when terraform v0.12.0 is released.

The issue is located here: `https://github.com/hashicorp/terraform/issues/12570`