### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ module "network-security-group" {
   num_masters                    = "${var.num_masters}"
   num_private_agents             = "${var.num_private_agents}"
   num_public_agents              = "${var.num_public_agents}"
+  adminrouter_grpc_proxy_port    = "${var.adminrouter_grpc_proxy_port}"
 
   resource_group_name = "${azurerm_resource_group.rg.name}"
   tags                = "${var.tags}"
@@ -112,6 +113,7 @@ module "loadbalancers" {
   public_agents_instance_nic_ids = ["${module.public_agents.instance_nic_ids}"]
   num_masters                    = "${var.num_masters}"
   num_public_agents              = "${var.num_public_agents}"
+  adminrouter_grpc_proxy_port    = "${var.adminrouter_grpc_proxy_port}"
 
   resource_group_name = "${azurerm_resource_group.rg.name}"
   tags                = "${var.tags}"

--- a/variables.tf
+++ b/variables.tf
@@ -220,3 +220,8 @@ variable "avset_platform_fault_domain_count" {
   description = "Availability set platform fault domain count, differs from location to location"
   default     = 3
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476